### PR TITLE
chore: add google form submission link

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -10,9 +10,10 @@ export default (children) => (
 ## Goals
 
 The Fiveable Open Source Initiative aims to create more community and opportunities for students interested in
-all things STEM and coding related. No prior experience is necessary. On this website, students will have the
-opportunity to submit their open-source projects to be featured on the website. This website also serves as a
-resource for students to discover open source projects to contribute to.
+all things STEM and coding related. No prior experience is necessary. Through
+[this form](https://forms.gle/ntDNx9KQoxLe5vXb6), students have the opportunity to submit their open-source
+projects to be featured on the website. This website also serves as a resource for students to discover open
+source projects to contribute to.
 
 ## What is open source?
 


### PR DESCRIPTION
This pr adds the project submission form to the about page.

Should it be its own section as opposed to just a link?