### PR TITLE
feat: add module caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,11 @@
-
 name: Build
-
-on: [push, pull_request]
-
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,7 +16,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14'
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Install dependencies
-        run: npm ci 
+        run: npm i 
       - name: Build
         run: npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,11 @@
-
 name: Lint and Format
-
-on: [push, pull_request]
-
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -13,7 +16,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14'
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm i
       - name: Run Linter
         run: npm run lint


### PR DESCRIPTION
This PR removes duplicate actions being run

also changes how our ci functions.
Our current CI setup goes like: `setup -> install modules -> run`.
To decrease the amount of time our actions take, we can do `setup -> use cached modules, if none then install & cache -> run`.