### PR TITLE
fix: add class [focus:outline-none]

### DIFF
--- a/components/searchbar.js
+++ b/components/searchbar.js
@@ -12,7 +12,7 @@ export default function SearchBar() {
         <div className="m-2 flex flex-row rounded-full bg-white sm:h-auto sm:w-3/5 md:w-2/5 sm:mr-8 md:mr-16">
             <input
                 type="text"
-                className="bg-transparent hidden w-full sm:block p-2 px-4 text-xl font-rubik"
+                className="bg-transparent hidden w-full sm:block p-2 px-4 text-xl font-rubik focus:outline-none"
                 placeholder="Search projects"
                 autoComplete="off"
                 name="search"


### PR DESCRIPTION
When focusing on the search form,  
<img width="704" alt="スクリーンショット 2021-05-02 12 22 16" src="https://user-images.githubusercontent.com/48167953/116801296-76400e00-ab43-11eb-88ce-69ef00671455.png">
delete outline
<img width="657" alt="スクリーンショット 2021-05-02 12 40 59" src="https://user-images.githubusercontent.com/48167953/116801318-b0111480-ab43-11eb-8bc4-cb8e426cbef1.png">

