### PR TITLE
fix: incorrect link on landing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -70,7 +70,7 @@ export default function Home() {
                         </Link>
                         <p className="text-xs">
                             Not sure where to start? Learn{" "}
-                            <Link href="/contributors">
+                            <Link href="/docs/git">
                                 <a className="underline font-bold">Git</a>
                             </Link>
                             .


### PR DESCRIPTION
This commit changes the link from `/contributors` to `/docs/git`.