### PR TITLE
feat: underline links

### DIFF
--- a/components/MDXComponents.js
+++ b/components/MDXComponents.js
@@ -9,7 +9,9 @@ const CustomLink = (props) => {
     if (isInternalLink) {
         return (
             <Link href={href}>
-                <a {...props} className="font-semibold hover:text-gray-500 underline">{props.children}</a>
+                <a {...props} className="font-semibold hover:text-gray-500 underline">
+                    {props.children}
+                </a>
             </Link>
         );
     }

--- a/components/MDXComponents.js
+++ b/components/MDXComponents.js
@@ -9,7 +9,7 @@ const CustomLink = (props) => {
     if (isInternalLink) {
         return (
             <Link href={href}>
-                <a {...props}>{props.children}</a>
+                <a {...props} className="font-semibold hover:text-gray-500 underline">{props.children}</a>
             </Link>
         );
     }
@@ -17,7 +17,7 @@ const CustomLink = (props) => {
     return (
         <a
             target="_blank"
-            className="font-semibold hover:text-gray-500 hover:underline"
+            className="font-semibold hover:text-gray-500 underline"
             rel="noopener noreferrer"
             {...props}>
             {props.children}

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -29,4 +29,4 @@ can be found [here](https://github.com/ThinkFiveable/open). We are currently acc
 source projects
 [here](https://docs.google.com/forms/d/e/1FAIpQLSeMuqyb8Tdf3Z2oY0kkFN7frYQT9RX97X09diiCW6FtoFZ1rQ/viewform).
 
-Don't know where to start? Check out our **[Git tutorials](/docs/git)**.
+Don't know where to start? Check out our [Git tutorials](/docs/git).


### PR DESCRIPTION
Closes #76

---

This PR adds underlines to links (in `<Link></Link>` and standalone `<a></a>`) tags within MDX rendered pages. It also normalizes styles between on-site links and off-site links so no discrepancies in Markdown are needed.