### PR TITLE
chore: add instructions for submitting through PRs

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -36,6 +36,7 @@ Head over to our [GitHub repository](https://github.com/thinkfiveable/open) and 
 ```json
      {
         "repoName": "Name of your repo here",
+        "repoLogo": "(optional) Attach a link to a cover image for your repo",
         "repoOwner": "GitHub username here",
         "projectType": "Type of project",
         "projectDescription": "Describe your project here."

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -10,10 +10,10 @@ export default (children) => (
 ## Goals
 
 The Fiveable Open Source Initiative aims to create more community and opportunities for students interested in
-all things STEM and coding related. No prior experience is necessary. Through
-[this form](https://forms.gle/ntDNx9KQoxLe5vXb6), students have the opportunity to submit their open-source
-projects to be featured on the website. This website also serves as a resource for students to discover open
-source projects to contribute to.
+all things STEM and coding related. No prior experience is necessary. Students have the opportunity to submit
+their open-source projects through making a pull request on this
+[repository](https://github.com/ThinkFiveable/open) to be featured on the website. This website also serves as
+a resource for students to discover open source projects to contribute to.
 
 ## What is open source?
 
@@ -26,7 +26,21 @@ source project has a license that determines the way people can use, distribute,
 Join the Fiveable Discord server at [discord.gg/thinkfiveable](https://discord.gg/thinkfiveable) and check out
 the #open-source channel which serves as the main discussion forum for this initiative. The GitHub repository
 can be found [here](https://github.com/ThinkFiveable/open). We are currently accepting submissions for open
-source projects
-[here](https://docs.google.com/forms/d/e/1FAIpQLSeMuqyb8Tdf3Z2oY0kkFN7frYQT9RX97X09diiCW6FtoFZ1rQ/viewform).
+source projects through pull requests.
 
-Don't know where to start? Check out our [Git tutorials](/docs/git).
+## How do I submit my project?
+
+Head over to our [GitHub repository](https://github.com/thinkfiveable/open) and navigate to the file
+`PROJECTS.JSON` located in the directory `data`. Add the information for your project in the following format:
+
+```json
+     {
+        "repoName": "Name of your repo here",
+        "repoOwner": "GitHub username here",
+        "projectType": "Type of project",
+        "projectDescription": "Describe your project here."
+    },
+```
+
+Then, make a pull request, and ask someone to review it! If you need any help, check out our
+[Git tutorials](/docs/git) or ask in the #open-source channel on the Discord!


### PR DESCRIPTION
This PR changes the copy on `/about` to reflect the process for submitting projects through PRs.